### PR TITLE
Fix panic caused by a malformed input

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -82,7 +82,7 @@ impl<T: ReadBytesExt> convert::TryFrom<T> for Packet {
         let precision = rdr.read_i8()?;
         let delay = rdr.read_u32::<NetworkEndian>()?.into();
         let dispersion = rdr.read_u32::<NetworkEndian>()?.into();
-        let ref_id_raw = rdr.read_u32::<NetworkEndian>().unwrap();
+        let ref_id_raw = rdr.read_u32::<NetworkEndian>()?.into();
         let ref_id = if stratum.primary() {
             let source = PrimarySource::try_from(ref_id_raw)?;
             ReferenceIdentifier::Primary(source)


### PR DESCRIPTION
Converting from bytes to a Packet struct can fail and the unwrap will
cause a panic. All other lines use `?.into()` - which fixes the issue.

An example of a malformed input would be:

    `0x23,0xc,0xfd,0x0,0x0,0x0,0x0,0x0,0x0,0x2a,0x0,0x0,0x0,0x0`

Found using `cargo-fuzz.`