### PR TITLE
updated error_chain to 0.11, byteorder to 1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+*.swp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ backtrace = ["error-chain/backtrace"]
 
 
 [dependencies]
-byteorder = "0.5.3"
+byteorder = "1.1"
 conv = "0.3.2"
 custom_derive = "0.1.5"
 log = "0.3.6"
 time = "0.1.35"
 
 [dependencies.error-chain]
-version = "0.10.0"
+version = "0.11.0"
 default-features = false

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -113,7 +113,6 @@ impl From<Packet> for Vec<u8> {
 mod tests {
     use std::io::Cursor;
     use super::Packet;
-    use std::convert::TryFrom;
     use formats::{
         LeapIndicator,
         Version,


### PR DESCRIPTION
changes:
- updated `error_chain` to `0.11`
- updated `byteorder` to `1.1`
- fixed tests failing to build on stable

imo, you can close #2 and #6

can you also make a new release?