### PR TITLE
Add an examples directory with a simple request demonstration

### DIFF
--- a/examples/request.rs
+++ b/examples/request.rs
@@ -1,0 +1,10 @@
+//! How to request an NTP packet from an NTP server.
+
+extern crate ntp;
+
+fn main() {
+    let address = "0.pool.ntp.org:123";
+    let response: ntp::packet::Packet = ntp::request(address).unwrap();
+    let ntp_time = response.transmit_time;
+    println!("{}", ntp_time);
+}


### PR DESCRIPTION
This is a copy of the example from the root documentation, but a little easier for user's to run and experiment with via `cargo run --example request`.

Note: this example will need to be updated if #18 is merged - I'm happy to do so if it does.