### PR TITLE
Remove use of `time` crate in favour of using `std::time`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,10 @@ byteorder = "1.1"
 conv = "0.3.2"
 custom_derive = "0.1.5"
 log = "0.3.6"
-time = "0.1.35"
 
 [dependencies.error-chain]
 version = "0.12.0"
 default-features = false
+
+[dev-dependencies]
+chrono = "0.4.4"

--- a/examples/request.rs
+++ b/examples/request.rs
@@ -1,10 +1,14 @@
 //! How to request an NTP packet from an NTP server.
 
+extern crate chrono;
 extern crate ntp;
+
+use chrono::TimeZone;
 
 fn main() {
     let address = "0.pool.ntp.org:123";
     let response: ntp::packet::Packet = ntp::request(address).unwrap();
-    let ntp_time = response.transmit_time;
-    println!("{}", ntp_time);
+    let unix_time = ntp::unix_time::Instant::from(response.transmit_time);
+    let local_time = chrono::Local.timestamp(unix_time.secs(), unix_time.subsec_nanos() as _);
+    println!("{}", local_time);
 }

--- a/src/formats/timestamp.rs
+++ b/src/formats/timestamp.rs
@@ -1,6 +1,4 @@
-extern crate time;
-
-use std::fmt;
+use unix_time;
 
 pub static EPOCH_DELTA: i64 = 2208988800i64;
 static NTP_SCALE: f64 = 4294967295.0_f64;
@@ -11,27 +9,18 @@ pub struct ShortFormat {
     pub frac: u16,
 }
 
-impl fmt::Display for ShortFormat {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let t = time::at(time::Timespec::from(*self));
-        write!(f, "{}", t.asctime())
+impl From<ShortFormat> for unix_time::Instant {
+    fn from(t: ShortFormat) -> unix_time::Instant {
+        let secs = t.sec as i64 - EPOCH_DELTA;
+        let subsec_nanos = (t.frac as f64 / NTP_SCALE * 1e9) as i32;
+        unix_time::Instant::new(secs, subsec_nanos)
     }
 }
 
-// Conversions
-impl From<ShortFormat> for time::Timespec {
-    fn from(t: ShortFormat) -> time::Timespec {
-        time::Timespec::new(
-            t.sec as i64 - EPOCH_DELTA,
-            (t.frac as f64 / NTP_SCALE * 1e9) as i32,
-        )
-    }
-}
-
-impl From<time::Timespec> for ShortFormat {
-    fn from(t: time::Timespec) -> ShortFormat {
-        let sec = t.sec + EPOCH_DELTA;
-        let frac = t.nsec as f64 * NTP_SCALE / 1e10;
+impl From<unix_time::Instant> for ShortFormat {
+    fn from(t: unix_time::Instant) -> ShortFormat {
+        let sec = t.secs() + EPOCH_DELTA;
+        let frac = t.subsec_nanos() as f64 * NTP_SCALE / 1e10;
         ShortFormat { sec: sec as u16, frac: frac as u16 }
     }
 }
@@ -58,27 +47,19 @@ pub struct TimestampFormat {
     pub frac: u32,
 }
 
-impl fmt::Display for TimestampFormat {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let t = time::at(time::Timespec::from(*self));
-        write!(f, "{}", t.asctime())
-    }
-}
-
-impl From<TimestampFormat> for time::Timespec {
-    fn from(t: TimestampFormat) -> time::Timespec {
-        time::Timespec::new(
-            t.sec as i64 - EPOCH_DELTA,
-            (t.frac as f64 / NTP_SCALE * 1e9) as i32,
-        )
-    }
-}
-
-impl From<time::Timespec> for TimestampFormat {
-    fn from(t: time::Timespec) -> TimestampFormat {
-        let sec = t.sec + EPOCH_DELTA;
-        let frac = t.nsec as f64 * NTP_SCALE / 1e10;
+impl From<unix_time::Instant> for TimestampFormat {
+    fn from(t: unix_time::Instant) -> TimestampFormat {
+        let sec = t.secs() + EPOCH_DELTA;
+        let frac = t.subsec_nanos() as f64 * NTP_SCALE / 1e10;
         TimestampFormat { sec: sec as u32, frac: frac as u32 }
+    }
+}
+
+impl From<TimestampFormat> for unix_time::Instant {
+    fn from(t: TimestampFormat) -> unix_time::Instant {
+        let secs = t.sec as i64 - EPOCH_DELTA;
+        let subsec_nanos = (t.frac as f64 / NTP_SCALE * 1e9) as i32;
+        unix_time::Instant::new(secs, subsec_nanos)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,17 @@
 # Example
 
 ```rust
+extern crate chrono;
+extern crate ntp;
+
+use chrono::TimeZone;
+
 fn main() {
     let address = "0.pool.ntp.org:123";
     let response: ntp::packet::Packet = ntp::request(address).unwrap();
-    let ntp_time = response.transmit_time;
-    println!("{}", ntp_time);
+    let unix_time = ntp::unix_time::Instant::from(response.transmit_time);
+    let local_time = chrono::Local.timestamp(unix_time.secs(), unix_time.subsec_nanos() as _);
+    println!("{}", local_time);
 }
 ```
 */
@@ -18,7 +24,6 @@ fn main() {
 #[macro_use] extern crate error_chain;
 #[macro_use] extern crate log;
 extern crate byteorder;
-extern crate time;
 
 use std::io::Cursor;
 use std::net::{ToSocketAddrs,UdpSocket};
@@ -29,6 +34,7 @@ use std::time::Duration;
 pub mod errors;
 pub mod formats;
 pub mod packet;
+pub mod unix_time;
 
 pub fn request<A: ToSocketAddrs>(addr: A) -> errors::Result<packet::Packet> {
     let data: Vec<u8> = packet::Packet::new_client().into();

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -1,6 +1,3 @@
-extern crate time;
-
-
 use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
 use conv::TryFrom;
 use errors::*;
@@ -13,7 +10,7 @@ use formats::{
     PrimarySource
 };
 use formats::timestamp::{ShortFormat, TimestampFormat};
-
+use unix_time;
 
 #[derive(Debug, PartialEq, Default)]
 pub struct Packet {
@@ -34,11 +31,12 @@ pub struct Packet {
 
 impl Packet {
     pub fn new_client() -> Packet {
-        trace!("{}", TimestampFormat::from(time::now().to_timespec()));
+        let transmit_time = unix_time::Instant::now().into();
+        trace!("{:?}", transmit_time);
         Packet {
             mode: Mode::Client,
             vn: Version::Ver2,
-            transmit_time: time::now().to_timespec().into(),
+            transmit_time,
             ..Default::default()
         }
     }

--- a/src/unix_time.rs
+++ b/src/unix_time.rs
@@ -1,0 +1,89 @@
+use std::time;
+
+/// Describes an instant relative to the `UNIX_EPOCH` - 00:00:00 Coordinated Universal Time (UTC),
+/// Thursay, 1 January 1970 in seconds with the fractional part in nanoseconds.
+///
+/// If the **Instant** describes some moment prior to `UNIX_EPOCH`, both the `secs` and
+/// `subsec_nanos` components will be negative.
+///
+/// The sole purpose of this type is for retrieving the "current" time using the `std::time` module
+/// and for converting between the ntp timestamp formats. If you are interested in converting from
+/// unix time to some other more human readable format, perhaps see the [chrono
+/// crate](https://crates.io/crates/chrono).
+///
+/// ## Example
+///
+/// Here is a demonstration of displaying the **Instant** in local time using the chrono crate:
+///
+/// ```
+/// extern crate chrono;
+/// extern crate ntp;
+///
+/// use chrono::TimeZone;
+///
+/// fn main() {
+///     let unix_time = ntp::unix_time::Instant::now();
+///     let local_time = chrono::Local.timestamp(unix_time.secs(), unix_time.subsec_nanos() as _);
+///     println!("{}", local_time);
+/// }
+/// ```
+#[derive(Copy, Clone, Debug)]
+pub struct Instant {
+    secs: i64,
+    subsec_nanos: i32,
+}
+
+impl Instant {
+    /// Create a new **Instant** given its `secs` and `subsec_nanos` components.
+    ///
+    /// To indicate a time following `UNIX_EPOCH`, both `secs` and `subsec_nanos` must be positive.
+    /// To indicate a time prior to `UNIX_EPOCH`, both `secs` and `subsec_nanos` must be negative.
+    /// Violating these invariants will result in a **panic!**.
+    pub fn new(secs: i64, subsec_nanos: i32) -> Instant {
+        if secs > 0 && subsec_nanos < 0 {
+            panic!("invalid instant: secs was positive but subsec_nanos was negative");
+        }
+        if secs < 0 && subsec_nanos > 0 {
+            panic!("invalid instant: secs was negative but subsec_nanos was positive");
+        }
+        Instant { secs, subsec_nanos }
+    }
+
+    /// Uses `std::time::SystemTime::now` and `std::time::UNIX_EPOCH` to determine the current
+    /// **Instant**.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// extern crate ntp;
+    ///
+    /// fn main() {
+    ///     println!("{:?}", ntp::unix_time::Instant::now());
+    /// }
+    /// ```
+    pub fn now() -> Self {
+        match time::SystemTime::now().duration_since(time::UNIX_EPOCH) {
+            Ok(duration) => {
+                let secs = duration.as_secs() as i64;
+                let subsec_nanos = duration.subsec_nanos() as i32;
+                Instant::new(secs, subsec_nanos)
+            },
+            Err(sys_time_err) => {
+                let duration_pre_unix_epoch = sys_time_err.duration();
+                let secs = -(duration_pre_unix_epoch.as_secs() as i64);
+                let subsec_nanos = -(duration_pre_unix_epoch.subsec_nanos() as i32);
+                Instant::new(secs, subsec_nanos)
+            },
+        }
+    }
+
+    /// The "seconds" component of the **Instant**.
+    pub fn secs(&self) -> i64 {
+        self.secs
+    }
+
+    /// The fractional component of the **Instant** in nanoseconds.
+    pub fn subsec_nanos(&self) -> i32 {
+        self.subsec_nanos
+    }
+}


### PR DESCRIPTION
See #14 for the lead-up to this change.

This adds a new `unix_time::Instant` type which fills the role
previously occupied by the `time::Timespec` type. Specifically:

- Retrieving current unix time.
- Converting between `ShortFormat` and `TimestampFormat` types.

However, note that the `std::fmt::Display` implementation has been
removed as a result. Instead, the documentation suggests the user
considers the `chrono` crate if they desire conversions to or from more
human-readable formats. A doc example is provided demonstrating how to
pretty print a `unix_time::Instant` using the `chrono` crate. This
allows us to remove the crate dependency and keep the ntp crate scope a
little more narrow.

Closes #14.