### PR TITLE
Run rustfmt on the codebase

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ extern crate conv;
 extern crate log;
 extern crate byteorder;
 
-use protocol::{ReadBytes, ConstPackedSizeBytes, WriteBytes};
+use protocol::{ConstPackedSizeBytes, ReadBytes, WriteBytes};
 use std::io;
 use std::net::{ToSocketAddrs, UdpSocket};
 use std::time::Duration;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -242,11 +242,11 @@ pub enum ReferenceIdentifier {
 // Convert an ascii string to a big-endian u32.
 macro_rules! code_to_u32 {
     ($w:expr) => {
-        (($w[3] as u32) << 0) |
-        (($w[2] as u32) << 8) |
-        (($w[1] as u32) << 16) |
-        (($w[0] as u32) << 24) |
-        ((*$w as [u8; 4])[0] as u32 * 0)
+        (($w[3] as u32) << 0)
+            | (($w[2] as u32) << 8)
+            | (($w[1] as u32) << 16)
+            | (($w[0] as u32) << 24)
+            | ((*$w as [u8; 4])[0] as u32 * 0)
     };
 }
 
@@ -307,7 +307,7 @@ custom_derive! {
     /// for an intelligent client, either NTPv4 or SNTPv4. Kiss codes are encoded in four-character
     /// ASCII strings that are left justified and zero filled. The strings are designed for
     /// character displays and log files.
-    /// 
+    ///
     /// Recipients of kiss codes MUST inspect them and, in the following cases, take the actions
     /// described.
     #[repr(u32)]
@@ -513,8 +513,7 @@ impl ConstPackedSizeBytes for PacketByte1 {
 }
 
 impl ConstPackedSizeBytes for Packet {
-    const PACKED_SIZE_BYTES: usize =
-        PacketByte1::PACKED_SIZE_BYTES
+    const PACKED_SIZE_BYTES: usize = PacketByte1::PACKED_SIZE_BYTES
         + Stratum::PACKED_SIZE_BYTES
         + 2
         + ShortFormat::PACKED_SIZE_BYTES * 2
@@ -655,7 +654,11 @@ impl ReadFromBytes for DateFormat {
         let era_number = reader.read_i32::<BE>()?;
         let era_offset = reader.read_u32::<BE>()?;
         let fraction = reader.read_u64::<BE>()?;
-        let date_format = DateFormat { era_number, era_offset, fraction };
+        let date_format = DateFormat {
+            era_number,
+            era_offset,
+            fraction,
+        };
         Ok(date_format)
     }
 }
@@ -678,7 +681,7 @@ impl ReadFromBytes for (LeapIndicator, Version, Mode) {
             None => {
                 let err_msg = "unknown leap indicator";
                 return Err(io::Error::new(io::ErrorKind::InvalidData, err_msg));
-            },
+            }
         };
         let vn = Version(vn_u8);
         let mode = match Mode::try_from(mode_u8).ok() {
@@ -686,7 +689,7 @@ impl ReadFromBytes for (LeapIndicator, Version, Mode) {
             None => {
                 let err_msg = "unknown association mode";
                 return Err(io::Error::new(io::ErrorKind::InvalidData, err_msg));
-            },
+            }
         };
         Ok((li, vn, mode))
     }

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -1,16 +1,16 @@
 extern crate ntp;
 
 use ntp::protocol::{
-    LeapIndicator, Mode, ShortFormat, PrimarySource, ReadBytes, Packet, ReferenceIdentifier,
-    ConstPackedSizeBytes, Stratum, TimestampFormat, Version, WriteBytes,
+    ConstPackedSizeBytes, LeapIndicator, Mode, Packet, PrimarySource, ReadBytes,
+    ReferenceIdentifier, ShortFormat, Stratum, TimestampFormat, Version, WriteBytes,
 };
 
 #[test]
 fn packet_from_bytes() {
     let input = [
-        20u8, 1, 3, 240, 0, 0, 0, 0, 0, 0, 0, 24, 67, 68, 77, 65, 215, 188, 128, 105, 198, 169,
-        46, 99, 215, 187, 177, 194, 159, 47, 120, 0, 215, 188, 128, 113, 45, 236, 230, 45, 215,
-        188, 128, 113, 46, 35, 158, 108,
+        20u8, 1, 3, 240, 0, 0, 0, 0, 0, 0, 0, 24, 67, 68, 77, 65, 215, 188, 128, 105, 198, 169, 46,
+        99, 215, 187, 177, 194, 159, 47, 120, 0, 215, 188, 128, 113, 45, 236, 230, 45, 215, 188,
+        128, 113, 46, 35, 158, 108,
     ];
     let expected_output = Packet {
         leap_indicator: LeapIndicator::NoWarning,
@@ -19,8 +19,14 @@ fn packet_from_bytes() {
         stratum: Stratum::PRIMARY,
         poll: 3,
         precision: -16,
-        root_delay: ShortFormat { seconds: 0, fraction: 0 },
-        root_dispersion: ShortFormat { seconds: 0, fraction: 24 },
+        root_delay: ShortFormat {
+            seconds: 0,
+            fraction: 0,
+        },
+        root_dispersion: ShortFormat {
+            seconds: 0,
+            fraction: 24,
+        },
         reference_id: ReferenceIdentifier::PrimarySource(PrimarySource::Cdma),
         reference_timestamp: TimestampFormat {
             seconds: 3619455081,
@@ -47,9 +53,9 @@ fn packet_from_bytes() {
 #[test]
 fn packet_to_bytes() {
     let expected_output = [
-        20, 1, 3, 240, 0, 0, 0, 0, 0, 0, 0, 24, 67, 68, 77, 65, 215, 188, 128, 105, 198, 169,
-        46, 99, 215, 187, 177, 194, 159, 47, 120, 0, 215, 188, 128, 113, 45, 236, 230, 45, 215,
-        188, 128, 113, 46, 35, 158, 108,
+        20, 1, 3, 240, 0, 0, 0, 0, 0, 0, 0, 24, 67, 68, 77, 65, 215, 188, 128, 105, 198, 169, 46,
+        99, 215, 187, 177, 194, 159, 47, 120, 0, 215, 188, 128, 113, 45, 236, 230, 45, 215, 188,
+        128, 113, 46, 35, 158, 108,
     ];
     let input = Packet {
         leap_indicator: LeapIndicator::NoWarning,
@@ -58,8 +64,14 @@ fn packet_to_bytes() {
         stratum: Stratum::PRIMARY,
         poll: 3,
         precision: -16,
-        root_delay: ShortFormat { seconds: 0, fraction: 0 },
-        root_dispersion: ShortFormat { seconds: 0, fraction: 24 },
+        root_delay: ShortFormat {
+            seconds: 0,
+            fraction: 0,
+        },
+        root_dispersion: ShortFormat {
+            seconds: 0,
+            fraction: 24,
+        },
         reference_id: ReferenceIdentifier::PrimarySource(PrimarySource::Cdma),
         reference_timestamp: TimestampFormat {
             seconds: 3619455081,
@@ -86,9 +98,9 @@ fn packet_to_bytes() {
 #[test]
 fn packet_conversion_roundtrip() {
     let input = [
-        20, 1, 3, 240, 0, 0, 0, 0, 0, 0, 0, 24, 67, 68, 77, 65, 215, 188, 128, 105, 198, 169,
-        46, 99, 215, 187, 177, 194, 159, 47, 120, 0, 215, 188, 128, 113, 45, 236, 230, 45, 215,
-        188, 128, 113, 46, 35, 158, 108,
+        20, 1, 3, 240, 0, 0, 0, 0, 0, 0, 0, 24, 67, 68, 77, 65, 215, 188, 128, 105, 198, 169, 46,
+        99, 215, 187, 177, 194, 159, 47, 120, 0, 215, 188, 128, 113, 45, 236, 230, 45, 215, 188,
+        128, 113, 46, 35, 158, 108,
     ];
     let packet = (&input[..]).read_bytes::<Packet>().unwrap();
     let mut output = [0u8; Packet::PACKED_SIZE_BYTES];


### PR DESCRIPTION
As configured (with defaults).

If a different style is preferred, it would be helpful to configure it in a `rustfmt.toml` file.