### PR TITLE
Coding-Badly/allow-log-upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["date-and-time", "network-programming", "parser-implementations", 
 byteorder = "1.1"
 conv = "0.3.2"
 custom_derive = "0.1.5"
-log = "0.3.6"
+log = ">= 0.3.6, <= 0.4"
 
 [dev-dependencies]
 chrono = "0.4.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,11 +88,12 @@ pub fn request<A: ToSocketAddrs>(addr: A) -> io::Result<protocol::Packet> {
 
     // Send the data.
     let sz = sock.send_to(&bytes, addr)?;
-    debug!("{:?}", sock.local_addr());
-    debug!("sent: {}", sz);
 
     // Receive the response.
     let res = sock.recv(&mut bytes[..])?;
+
+    debug!("{:?}", sock.local_addr());
+    debug!("sent: {}", sz);
     debug!("recv: {:?}", res);
     debug!("{:?}", &bytes[..]);
 


### PR DESCRIPTION
**Background**

We have a desire to use the most recent version of the `log` crate.

**Change**

This update changes the version requirement for the `log` crate so it can be upgrade to the latest version.

**Notes**

The timing in `request` (between `send_to` and `recv`) is critical.  The new `debug!` is slow enough to cause the response to be missed.  Moving all the `debug!` calls later helped.
